### PR TITLE
Fix Flickering on render using correct unbinding

### DIFF
--- a/src/main/java/de/florianmichael/imguiexample/imgui/ImGuiImpl.java
+++ b/src/main/java/de/florianmichael/imguiexample/imgui/ImGuiImpl.java
@@ -87,7 +87,7 @@ public class ImGuiImpl {
         ImGui.render();
         imGuiImplGl3.renderDrawData(ImGui.getDrawData());
 
-        GlStateManager._glBindFramebuffer(GL30.GL_FRAMEBUFFER, previousFramebuffer);
+        GlStateManager._glBindFramebuffer(GL30.GL_FRAMEBUFFER, 0);
 
 // Add this code if you have enabled Viewports in the create method
 //        if (ImGui.getIO().hasConfigFlags(ImGuiConfigFlags.ViewportsEnable)) {

--- a/src/main/java/de/florianmichael/imguiexample/imgui/ImGuiImpl.java
+++ b/src/main/java/de/florianmichael/imguiexample/imgui/ImGuiImpl.java
@@ -71,8 +71,7 @@ public class ImGuiImpl {
     public static void draw(final RenderInterface renderInterface) {
         // Minecraft will not bind the framebuffer unless it is needed, so do it manually and hope Vulcan never gets real:tm:
         final Framebuffer framebuffer = MinecraftClient.getInstance().getFramebuffer();
-        final int previousFramebuffer = ((GlTexture) framebuffer.getColorAttachment()).getOrCreateFramebuffer(((GlBackend) RenderSystem.getDevice()).getBufferManager(), null);
-        GlStateManager._glBindFramebuffer(GL30.GL_FRAMEBUFFER, previousFramebuffer);
+        GlStateManager._glBindFramebuffer(GL30.GL_FRAMEBUFFER, ((GlTexture) framebuffer.getColorAttachment()).getOrCreateFramebuffer(((GlBackend) RenderSystem.getDevice()).getBufferManager(), null));
         GL11.glViewport(0, 0, framebuffer.textureWidth, framebuffer.textureHeight);
 
         // start frame


### PR DESCRIPTION
fixed flickering (atleast on linux) by unbinding the framebuffer correctly (using GlStateManager._glBindFramebuffer(GL30.GL_FRAMEBUFFER, 0);)