### PR TITLE
Removed the title screen ImGui and replace it with a button to the ExampleScreen()

### DIFF
--- a/src/main/java/de/florianmichael/imguiexample/imgui/ImGuiImpl.java
+++ b/src/main/java/de/florianmichael/imguiexample/imgui/ImGuiImpl.java
@@ -87,7 +87,7 @@ public class ImGuiImpl {
         ImGui.render();
         imGuiImplGl3.renderDrawData(ImGui.getDrawData());
 
-        GlStateManager._glBindFramebuffer(GL30.GL_FRAMEBUFFER, previousFramebuffer);
+        GlStateManager._glBindFramebuffer(GL30.GL_FRAMEBUFFER, 0);
 
 // Add this code if you have enabled Viewports in the create method
 //        if (ImGui.getIO().hasConfigFlags(ImGuiConfigFlags.ViewportsEnable)) {

--- a/src/main/java/de/florianmichael/imguiexample/imgui/ImGuiImpl.java
+++ b/src/main/java/de/florianmichael/imguiexample/imgui/ImGuiImpl.java
@@ -71,8 +71,7 @@ public class ImGuiImpl {
     public static void draw(final RenderInterface renderInterface) {
         // Minecraft will not bind the framebuffer unless it is needed, so do it manually and hope Vulcan never gets real:tm:
         final Framebuffer framebuffer = MinecraftClient.getInstance().getFramebuffer();
-        final int previousFramebuffer = ((GlTexture) framebuffer.getColorAttachment()).getOrCreateFramebuffer(((GlBackend) RenderSystem.getDevice()).getBufferManager(), null);
-        GlStateManager._glBindFramebuffer(GL30.GL_FRAMEBUFFER, previousFramebuffer);
+        GlStateManager._glBindFramebuffer(GL30.GL_FRAMEBUFFER, ((GlTexture) framebuffer.getColorAttachment()).getOrCreateFramebuffer(((GlBackend) RenderSystem.getDevice()).getBufferManager(), null));
         GL11.glViewport(0, 0, framebuffer.textureWidth, framebuffer.textureHeight);
 
         // start frame

--- a/src/main/java/de/florianmichael/imguiexample/mixin/TitleScreenMixin.java
+++ b/src/main/java/de/florianmichael/imguiexample/mixin/TitleScreenMixin.java
@@ -1,22 +1,34 @@
 package de.florianmichael.imguiexample.mixin;
 
 import de.florianmichael.imguiexample.imgui.RenderInterface;
+import de.florianmichael.imguiexample.screens.ExampleScreen;
 import imgui.ImGui;
 import imgui.ImGuiIO;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.TitleScreen;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.text.Text;
+import net.minecraft.world.gen.GeneratorOptions;
+import net.minecraft.world.gen.WorldPresets;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(TitleScreen.class)
-public class TitleScreenMixin implements RenderInterface {
+public class TitleScreenMixin extends Screen {
 
-    @Override
-    public void render(ImGuiIO io) {
-        ImGui.begin("Hello World");
-        // Draw something here, see the official example module for more information:
-        // https://github.com/ocornut/imgui/blob/master/imgui_demo.cpp
-        ImGui.end();
-
-        ImGui.showDemoWindow();
+    protected TitleScreenMixin(Text title) {
+        super(title);
     }
 
+    @Inject(method = "init", at = @At("RETURN"))
+    public void render(CallbackInfo ci) {
+        this.addDrawableChild(ButtonWidget.builder(Text.literal("ImGui Demo"), (button) -> {
+            MinecraftClient.getInstance().setScreen(new ExampleScreen());
+        }).dimensions(this.width - 75 - 3, 3, 70, 20).build());
+    }
 }


### PR DESCRIPTION
Removed the ImGui rendering on the TitleScreen directly, but replacing it with a button in the top-right, which takes you to the ExampleScreen 