### PR TITLE
Fix Linux crash due to LWJGL conflict

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,10 @@ dependencies {
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
 	include implementation("io.github.spair:imgui-java-binding:${project.imgui_version}")
-	include implementation("io.github.spair:imgui-java-lwjgl3:${project.imgui_version}")
+	include implementation("io.github.spair:imgui-java-lwjgl3:${project.imgui_version}") {
+		exclude group: 'org.lwjgl'
+		exclude group: 'org.lwjgl.lwjgl'
+	}
 
 	include implementation("io.github.spair:imgui-java-natives-windows:${project.imgui_version}")
 	include implementation("io.github.spair:imgui-java-natives-linux:${project.imgui_version}")

--- a/build.gradle
+++ b/build.gradle
@@ -41,8 +41,8 @@ dependencies {
 
 	include implementation("io.github.spair:imgui-java-binding:${project.imgui_version}")
 	include implementation("io.github.spair:imgui-java-lwjgl3:${project.imgui_version}") {
-		exclude group: 'org.lwjgl'
-		exclude group: 'org.lwjgl.lwjgl'
+		exclude group: "org.lwjgl"
+		exclude group: "org.lwjgl.lwjgl"
 	}
 
 	include implementation("io.github.spair:imgui-java-natives-windows:${project.imgui_version}")


### PR DESCRIPTION
Excludes LWJGL from the ImGui Bindings to prevent a crash on Linux. Tested on Linux (Wayland/Hyprland), untested on other OS's.